### PR TITLE
Updated LudolphBot class to _not_ inherit from ClientXMPP

### DIFF
--- a/ludolph/main.py
+++ b/ludolph/main.py
@@ -263,8 +263,8 @@ The example file is located in: %s\n\n""" % (
         signal.signal(signal.SIGHUP, sighup)
         # signal.siginterrupt(signal.SIGHUP, false)  # http://stackoverflow.com/a/4302037
 
-    if xmpp.connect(tuple(address), use_tls=use_tls, use_ssl=use_ssl):
-        xmpp.process(block=True)
+    if xmpp.client.connect(tuple(address), use_tls=use_tls, use_ssl=use_ssl):
+        xmpp.client.process(block=True)
         sys.exit(ret)
     else:
         logger.error('Ludolph is unable to connect to jabber server')

--- a/ludolph/message.py
+++ b/ludolph/message.py
@@ -114,7 +114,7 @@ class IncomingLudolphMessage(Message):
     def load(cls, data):
         from ludolph.bot import get_xmpp
 
-        obj = cls(stream=get_xmpp())
+        obj = cls(stream=get_xmpp().client)
 
         # First set our custom attributes
         for i in cls._ludolph_attrs:
@@ -231,8 +231,8 @@ class OutgoingLudolphMessage(object):
         """
         Send a new message.
         """
-        msg = xmpp.make_message(mto, self.mbody, msubject=self.msubject, mtype=self.mtype, mhtml=self.mhtml,
-                                mfrom=mfrom, mnick=mnick)
+        msg = xmpp.client.make_message(mto, self.mbody, msubject=self.msubject, mtype=self.mtype, mhtml=self.mhtml,
+                                       mfrom=mfrom, mnick=mnick)
 
         if self.timestamp:
             msg['delay'].set_stamp(self.timestamp)

--- a/ludolph/plugins/commands.py
+++ b/ludolph/plugins/commands.py
@@ -144,16 +144,17 @@ class Commands(LudolphPlugin):
         if self._pass_through_mode:
             logger.warning('You have enabled pass-through mode in the commands plugin. '
                            '_ALL_ bot commands will be passed to the operating system!')
-            # Override fallback message handler
+            # Override default bot_command_not_found message handler
             # noinspection PyUnresolvedReferences
-            self.xmpp.fallback_message = self.pass_through
+            self.xmpp.register_event_handler('bot_command_not_found', self.pass_through, clear=True)
             # No need for a "pass-through" command
             del self.xmpp.commands['pass-through']
 
     def __destroy__(self):
         if self._pass_through_mode:
-            # Recover original fallback message handler
-            self.xmpp.fallback_message = self.xmpp.original_fallback_message
+            # Remove our bot_command_not_found event handler
+            # noinspection PyUnresolvedReferences
+            self.xmpp.deregister_event_handler('bot_command_not_found', self.pass_through)
 
     # noinspection PyMethodMayBeStatic
     def _execute(self, msg, name, cmd, *args):

--- a/ludolph/plugins/muc.py
+++ b/ludolph/plugins/muc.py
@@ -88,7 +88,7 @@ class Muc(LudolphPlugin):
 
     def _set_room_subject(self, text, mfrom=None):
         """Set room subject"""
-        msg = self.xmpp.Message()
+        msg = self.xmpp.client.Message()
         msg['to'] = self.xmpp.room
         msg['from'] = mfrom
         msg['type'] = 'groupchat'


### PR DESCRIPTION
This change was made for two reasons:

* The LudolphBot instance in plugins (`self.xmpp`) should hide methods and attributes which are not ours so the user uses only our API and not sleekXMPP's.
* It should make things easier in the future when we switch SleekXMPP for something else.

The ClientXMPP instance is still available as `self.xmpp.client`, but should not be used by plugins.