### PR TITLE
Add support for XEP-0224 Attention

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ Features
 * `Alerts from Zabbix <https://github.com/erigones/Ludolph/wiki/How-to-configure-Zabbix-to-work-with-Ludolph>`_
 * Multi-User Chat (XEP-0045)
 * Colorful messages (XEP-0071)
+* Attention (XEP-0224)
 * `Avatars (XEP-0084) <https://github.com/erigones/Ludolph/wiki/F.A.Q.#how-to-set-an-avatar>`_
 * `Roster management and ACL configuration <https://github.com/erigones/Ludolph/wiki/User-subscription-management>`_
 * `Webhooks and cron jobs <https://github.com/erigones/Ludolph/wiki/Webhooks-and-cron-jobs>`_
@@ -30,6 +31,7 @@ Features
     * ludolph.plugins.base
         * about - details about this project
         * at - list, add, or delete jobs for later execution
+        * attention - send XMPP attention to user/room
         * avatar - list available avatars or set an avatar for Ludolph (admin only)
         * broadcast - sent private message to every user in roster (admin only)
         * help - show this help

--- a/ludolph/bot.py
+++ b/ludolph/bot.py
@@ -151,6 +151,7 @@ class LudolphBot(LudolphDBMixin):
         client.register_plugin('xep_0203')  # Delayed Delivery
         client.register_plugin('xep_0084')  # User Avatar
         client.register_plugin('xep_0153')  # User Avatar vCard
+        client.register_plugin('xep_0224')  # Attention
 
         # Auto-authorize is enabled by default. User subscriptions are controlled by self._handle_new_subscription
         client.auto_authorize = True
@@ -161,6 +162,7 @@ class LudolphBot(LudolphDBMixin):
         client.add_event_handler('roster_subscription_request', self._handle_new_subscription)
         client.add_event_handler('session_start', self._session_start)
         client.add_event_handler('message', self._bot_message, threaded=True)
+        client.add_event_handler('attention', self.handle_attention, threaded=True)
 
         if self.room:
             self.muc = client.plugin['xep_0045']
@@ -875,6 +877,9 @@ class LudolphBot(LudolphDBMixin):
         self._update_room_users_last_seen(muc['jid'].bare)
         # Fire the muc_user_offline event (nothing by default)
         self._run_event_handlers('muc_user_online', presence)
+
+    def handle_attention(self, msg):
+        self.msg_reply(msg, 'Whats up, buddy? If you are lost, type **help** to see what I am capable of...')
 
     # noinspection PyUnusedLocal
     def shutdown(self, signalnum, handler):

--- a/ludolph/plugins/base.py
+++ b/ludolph/plugins/base.py
@@ -211,6 +211,16 @@ class Base(LudolphPlugin):
         return '**Message broadcasted to %dx users.** Users on broadcast blacklist: %s.' % \
                (self.xmpp.msg_broadcast(text), ', '.join(self.xmpp.broadcast_blacklist))
 
+    # noinspection PyUnusedLocal
+    @command
+    def attention(self, msg, jid, text=None):
+        """
+        Send XMPP attention to user/room.
+
+        Usage: attention <JID> <text>
+        """
+        return self.xmpp.plugin['xep_0224'].request_attention(jid, mbody=text)
+
     def _set_status(self, show, status=None):
         """Send presence status"""
         if show not in self._status_show_types:


### PR DESCRIPTION
Add support for XEP-0224 Attention:

* User can send attention to Ludolph, he replies with message to use help.
* User can ask Ludolph to send attention to other user (similar functionality to message).