### PR TITLE
Fixed remind list command - closes erigones/ludolph#65

### DIFF
--- a/ludolph/plugins/base.py
+++ b/ludolph/plugins/base.py
@@ -1,6 +1,6 @@
 """
 Ludolph: Monitoring Jabber bot
-Copyright (C) 2012-2016 Erigones, s. r. o.
+Copyright (C) 2012-2017 Erigones, s. r. o.
 This file is part of Ludolph.
 
 See the file LICENSE for copying permission.
@@ -33,7 +33,8 @@ class Base(LudolphPlugin):
     _status_show_types = frozenset(['online', 'away', 'chat', 'dnd', 'xa'])  # online is a fake type translated to None
     _help_cache = None
     _cron_required = ('at', 'remind')
-    _reminder = '__You have asked me to remind you:__ '
+    _reminder = 'You have asked me to remind you: '
+    _reminder_command = 'attention'
 
     def __post_init__(self):
         # Disable at command if cron is disabled
@@ -401,13 +402,12 @@ class Base(LudolphPlugin):
 
         if reminder:
             display_job = lambda cronjob: cronjob.onetime and user == cronjob.owner \
-                and cronjob.command.split(' ')[:2] == ['message', user]
+                and cronjob.command.split(' ')[:2] == [self._reminder_command, user]
 
             out = ['**%s** [%s] __%s__' % (name, job.schedule,
                                            ' '.join(job.command.split(' ')[2:]).replace(self._reminder + ' ', ''))
                    for name, job in crontab.items() if display_job(job)]
         else:
-
             if self.xmpp.is_jid_admin(user):
                 display_job = lambda cronjob: cronjob.onetime
             else:
@@ -542,8 +542,8 @@ class Base(LudolphPlugin):
                 if args_count < 2:
                     raise MissingParameter
                 else:
-                    return self._at_add(msg, *(args[1], 'attention', self.xmpp.get_jid(msg), self._reminder) + args[2:],
-                                        at_reply_output=False)
+                    at_add_params = (args[1], self._reminder_command, self.xmpp.get_jid(msg), self._reminder) + args[2:]
+                    return self._at_add(msg, *at_add_params, at_reply_output=False)
             elif action == 'del':
                 if args_count < 2:
                     raise MissingParameter


### PR DESCRIPTION
The problem was introduced in commit ea7416e, where the message command was replaced by the attention command in reminders.