### PR TITLE
Added `drop_messages_to_dnd_users` option - closes #68

### DIFF
--- a/ludolph/bot.py
+++ b/ludolph/bot.py
@@ -892,7 +892,7 @@ class LudolphBot(LudolphDBMixin):
     # noinspection PyMethodMayBeStatic
     def _user_offline(self, presence):
         """
-        Process an online presence stanza from a JID.
+        Process an offline presence stanza from a JID.
         """
         logger.info('User "%s" got offline (%s)', presence['from'], presence.get_type())
 

--- a/ludolph/bot.py
+++ b/ludolph/bot.py
@@ -803,7 +803,11 @@ class LudolphBot(LudolphDBMixin):
         # Remove users with none subscription from roster
         # Also remove users that are not in users setting (if set)
         for i in tuple(roster.keys()):  # Copy for python 3
-            if roster[i]['subscription'] == 'none' or (self.users and i not in self.users):
+            if i == self.boundjid.bare:
+                logger.info('Roster item %s (%s) - ignoring myself', i, roster[i]['subscription'])
+            elif self.room and i == self.room:
+                logger.info('Roster item %s (%s) - ignoring my room', i, roster[i]['subscription'])
+            elif roster[i]['subscription'] == 'none' or (self.users and i not in self.users):
                 logger.warning('Roster item: %s (%s) - removing!', i, roster[i]['subscription'])
                 self.client.send_presence(pto=i, ptype='unsubscribe')
                 self.client.del_roster_item(i)

--- a/ludolph/bot.py
+++ b/ludolph/bot.py
@@ -1081,7 +1081,6 @@ class LudolphBot(LudolphDBMixin):
         """
         return OutgoingLudolphMessage.create(mbody, **kwargs).send(self, mto, mfrom=mfrom, mnick=mnick)
 
-    # noinspection PyMethodMayBeStatic
     def msg_reply(self, msg, mbody, preserve_msg=False, **kwargs):
         """
         Set message reply text and html, and send it.
@@ -1101,7 +1100,7 @@ class LudolphBot(LudolphDBMixin):
         defaults = {'mtype': msg.get('mtype', None), 'msubject': msg.get('subject', None)}
         defaults.update(kwargs)
 
-        return OutgoingLudolphMessage.create(msg['body'], **kwargs).send(self, msg['from'], mfrom=msg['to'])
+        return OutgoingLudolphMessage.create(msg['body'], **defaults).send(self, msg['from'], mfrom=msg['to'])
 
     def msg_broadcast(self, mbody, **kwargs):
         """

--- a/ludolph/ludolph.cfg.example
+++ b/ludolph/ludolph.cfg.example
@@ -90,12 +90,15 @@ admins =
 #room_admin_role =
 
 # Whether to send invites to new users to join the MUC room.
-# room_invites = True
+#room_invites = True
 
 # Comma-separated list of user jabber IDs.
 # Users will not receive message that will be broadcasted to Ludolph's roster.
 # You can use @admins keyword here.
-broadcast_blacklist = 
+#broadcast_blacklist =
+
+# Whether to skip sending of messages to users who have a DND status set (default: false)
+#drop_messages_to_dnd_users = false
 
 
 ###############################################################################

--- a/ludolph/plugins/base.py
+++ b/ludolph/plugins/base.py
@@ -209,7 +209,7 @@ class Base(LudolphPlugin):
 
         Usage: broadcast <message>
         """
-        return '**Message broadcasted to %dx users.** Users on broadcast blacklist: %s.' % \
+        return '**Message broadcasted to %d users.** Users on broadcast blacklist: %s' % \
                (self.xmpp.msg_broadcast(text), ', '.join(self.xmpp.broadcast_blacklist))
 
     # noinspection PyUnusedLocal


### PR DESCRIPTION
* 6172308 Added `drop_messages_to_dnd_users` option - closes erigones/Ludolph#68 - When a user has DND status the message will be dropped. This won't affect the remind command functionality because it uses attentions instead of messages.
* ce18df9 Fixed bug in `bot.msg_resend()` - a wrong parameter was passed
* a2f7475 Added exceptions into the `_roster_cleanup()` loop to ignore bot's and room's JID
* 87a4f06 Added handlers and methods for displaying and fetching user jabber status