### PR TITLE
Fixed bug in `drop_messages_to_dnd_users` feature in MUC room

### DIFF
--- a/ludolph/bot.py
+++ b/ludolph/bot.py
@@ -1086,7 +1086,7 @@ class LudolphBot(LudolphDBMixin):
         """
         Create message and send it.
         """
-        if self.drop_messages_to_dnd_users and self.has_jid_status(mto, 'dnd'):
+        if self.drop_messages_to_dnd_users and mto != self.room and self.has_jid_status(mto, 'dnd'):
             logger.warning('Dropping message for user "%s" because user status=dnd', mto)
             return False
 


### PR DESCRIPTION
The `drop_messages_to_dnd_users` feature was Introduced in issue #68 (PR #71).
However, in some cases messages sent to the MUC room were dropped when a
user with DND status was in the room. This fix disables the feature for
messages sent to MUC room.